### PR TITLE
Bugfix: percentage in widget_base.html

### DIFF
--- a/star_ratings/templates/star_ratings/widget_base.html
+++ b/star_ratings/templates/star_ratings/widget_base.html
@@ -32,7 +32,7 @@
                 {% endfor %}
             </ul>
 
-            <ul class="star-ratings-rating-foreground" style="width: {{ percentage }}%">
+            <ul class="star-ratings-rating-foreground" style="width: {{ percentage|floatformat }}%">
                 {% for star in stars %}
                     <li>
                     {% if user.is_authenticated %}


### PR DESCRIPTION
Problem showing percentage when loading or reloading a page where ratings appears.
I saw with the developer toolbar that 'percentage' uses ',' for decimals when my codification uses '.'.
So to correct it, I added '|floatformat' to {{ percentage }} in line 35