### PR TITLE
Use relative path for stars.png

### DIFF
--- a/star_ratings/static/star-ratings/css/star-ratings.css
+++ b/star_ratings/static/star-ratings/css/star-ratings.css
@@ -19,7 +19,7 @@
 /* line 20, ../sass/star-ratings.scss */
 .star-ratings-rating-full, .star-ratings-rating-empty {
   display: block;
-  background: url("/static/star-ratings/images/stars.png") no-repeat;
+  background: url("../images/stars.png") no-repeat;
 }
 
 /* line 25, ../sass/star-ratings.scss */


### PR DESCRIPTION
Relative path is used for the image as some people like to load their files from subdomain like static.example.com/star-ratings/images/stars.png