### PR TITLE
Change urlpatters to a list of django.conf.urls.url

### DIFF
--- a/star_ratings/urls.py
+++ b/star_ratings/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import patterns, url
 from .views import Rate
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'(?P<content_type_id>\d+)/(?P<object_id>\d+)/', Rate.as_view(), name='rate'),
-)
+]


### PR DESCRIPTION
django.conf.urls.patterns() is deprecated and will be removed in Django 1.10.Hence, urlpatterns is updated to be a list of django.conf.urls.url() instances instead.