### PR TITLE
Change urlpatters to a list of django.conf.urls.url

### DIFF
--- a/star_ratings/urls.py
+++ b/star_ratings/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import Rate
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'(?P<content_type_id>\d+)/(?P<object_id>\d+)/', Rate.as_view(), name='rate'),
-)
+]


### PR DESCRIPTION
Django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Hence, urlpatterns was updated to be a list of django.conf.urls.url() instances instead.