### PR TITLE
Added overridable object_id_pattern 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ the ``Rating`` model from your model:
 
     from django.contrib.contenttypes.fields import GenericRelation
     from star_ratings.models import Rating
-    
+
     class Foo(models.Model):
         bar = models.CharField(max_length=100)
         ratings = GenericRelation(Rating, related_query_name='foos')
@@ -180,14 +180,25 @@ Changing the ``pk`` type (Requires django >= 1.10)
 One use case for changing the rating model would be to change the pk type of the
 related object. By default we assume the pk of the rated object will be a
 positive integer field which is fine for most uses, if this isn't though you will
-need to override the ``object_id`` field on the rating model. As of django 1.10
-you can now hide fields form parent abstract models, so to change the ``object_id``
-to a ``CharField`` you can do something like:
+need to override the ``object_id`` field on the rating model as well as set
+STAR_RATINGS_OBJECT_ID_PATTERN to a reasonable value for your new pk field. As
+of django 1.10 you can now hide fields form parent abstract models, so to change
+the ``object_id``to a ``CharField`` you can do something like:
 
 ::
 
    class MyRating(AbstractBaseRating):
       object_id = models.CharField(max_length=10)
+
+And add the setting to the setting file:
+
+::
+
+   ./settings.py
+
+   ...
+   STAR_RATINGS_OBJECT_ID_PATTERN = '[a-z0-9]{32}'
+   ...
 
 
 Running tests

--- a/star_ratings/app_settings.py
+++ b/star_ratings/app_settings.py
@@ -27,3 +27,7 @@ class Settings:
     @property
     def STAR_RATINGS_STAR_SPRITE(self):
         return getattr(settings, 'STAR_RATINGS_STAR_SPRITE', '/static/star-ratings/images/stars.png')
+
+    @property
+    def STAR_RATINGS_OBJECT_ID_PATTERN(self):
+        return getattr(settings, 'STAR_RATINGS_OBJECT_ID_PATTERN', '\d+')

--- a/star_ratings/urls.py
+++ b/star_ratings/urls.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import url
+
 from .views import Rate
+from . import app_settings
 
 
 urlpatterns = [
-    url(r'(?P<content_type_id>\d+)/(?P<object_id>\d+)/', Rate.as_view(), name='rate'),
+    url(r'(?P<content_type_id>\d+)/(?P<object_id>' + app_settings.STAR_RATINGS_OBJECT_ID_PATTERN + ')/', Rate.as_view(), name='rate'),
 ]
 
 app_name = 'star_ratings'

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -47,3 +47,10 @@ class AppSettingsDefaults(TestCase):
     def test_star_width_defined_in_the_settings___value_is_setting_value(self, height, width):
         with override_settings(STAR_RATINGS_STAR_HEIGHT=height, STAR_RATINGS_STAR_WIDTH=width):
             self.assertEqual(width, app_settings.STAR_RATINGS_STAR_WIDTH)
+
+    def test_object_id_pattern_not_defined_in_the_settings___defaults_to_integers(self):
+        self.assertEqual('\d+', app_settings.STAR_RATINGS_OBJECT_ID_PATTERN)
+
+    @override_settings(STAR_RATINGS_OBJECT_ID_PATTERN='[a-z0-9]{32}')
+    def test_object_id_pattern_defined_in_the_settings___value_is_setting_value(self):
+        self.assertEqual('[a-z0-9]{32}', app_settings.STAR_RATINGS_OBJECT_ID_PATTERN)


### PR DESCRIPTION

Allows urls to be matched based on a new pattern.  This can be used by the new swappable model system to fully support changing the model pk to be a uuid or other identifier.

This fixes wildfish/django-star-ratings#127

