### PR TITLE
Add missing csrf token to context of template tag

### DIFF
--- a/star_ratings/templatetags/ratings.py
+++ b/star_ratings/templatetags/ratings.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 import uuid
 from django import template
 from django.template import loader
-from django.template.context_processors import csrf
 from django.templatetags.static import static
 
 from ..models import UserRating
@@ -40,7 +39,6 @@ def ratings(context, item, icon_height=app_settings.STAR_RATINGS_STAR_HEIGHT, ic
     # template name can be passed as a template parameter
     template_name = template_name or context.get('star_ratings_template_name') or 'star_ratings/widget.html'
     return loader.get_template(template_name).render({
-        'csrf_token': csrf(request)['csrf_token'],
         'rating': rating,
         'request': request,
         'user': request.user,
@@ -57,4 +55,4 @@ def ratings(context, item, icon_height=app_settings.STAR_RATINGS_STAR_HEIGHT, ic
         'anonymous_ratings': app_settings.STAR_RATINGS_ANONYMOUS,
         'read_only': read_only,
         'editable': not read_only and (is_authenticated(request.user) or app_settings.STAR_RATINGS_ANONYMOUS)
-    })
+    }, request=request)

--- a/star_ratings/templatetags/ratings.py
+++ b/star_ratings/templatetags/ratings.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import uuid
 from django import template
 from django.template import loader
+from django.template.context_processors import csrf
 from django.templatetags.static import static
 
 from ..models import UserRating
@@ -39,6 +40,7 @@ def ratings(context, item, icon_height=app_settings.STAR_RATINGS_STAR_HEIGHT, ic
     # template name can be passed as a template parameter
     template_name = template_name or context.get('star_ratings_template_name') or 'star_ratings/widget.html'
     return loader.get_template(template_name).render({
+        'csrf_token': csrf(request)['csrf_token'],
         'rating': rating,
         'request': request,
         'user': request.user,


### PR DESCRIPTION
Hi,

I'm using django-star-ratings via the template tag "ratings". When I started the development server I got a warning:

"A {% csrf_token %} was used in a template, but the context did not provide the value. This is usually caused by not using RequestContext."

After some digging I realized that [a commit](https://github.com/wildfish/django-star-ratings/commit/551dce3824656900c0f42e8e6df3a77767823558) back in July 2018 introduced csrf tokens to the widget base template, but the token was not added to the returned context in the template tag "ratings".

This pull request contains a commit, which adds the csrf token of the request to the returned context in the template tag "ratings".

Regards,
Alexis