### PR TITLE
fix: shows icon now instead of html in admin

### DIFF
--- a/star_ratings/admin.py
+++ b/star_ratings/admin.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from . import app_settings, get_star_ratings_rating_model
 from .models import UserRating
+from django.utils.html import format_html
 
 
 class UserRatingAdmin(admin.ModelAdmin):
@@ -14,7 +15,7 @@ class UserRatingAdmin(admin.ModelAdmin):
     def stars(self, obj):
         html = "<span style='display: block; width: {}px; height: 10px; " + \
                "background: url(/static/star-ratings/images/admin_stars.png)'>&nbsp;</span>"
-        return html.format(obj.score * 10)
+        return format_html(html, obj.score * 10)
 
     stars.allow_tags = True
     stars.short_description = _('Score')
@@ -32,7 +33,7 @@ class RatingAdmin(admin.ModelAdmin):
         html += "<span style='position: absolute; top: 0; left: 0; width: {}px; height: 10px; " + \
                 "background: url(/static/star-ratings/images/admin_stars.png)'>&nbsp;</span>"
         html += "</div>"
-        return html.format(app_settings.STAR_RATINGS_RANGE * 10, obj.average * 10)
+        return format_html(html, app_settings.STAR_RATINGS_RANGE * 10, obj.average * 10)
 
     stars.allow_tags = True
     stars.short_description = _('Rating average')


### PR DESCRIPTION
This fixes issue: #174 

`format_html` is available in Django 2.0+ (including 3.0), so there shouldn't be any compatibility issues for the currently supported Django versions.
