### PR TITLE
Satisfy deprecation warning under Django 3.0.3

### DIFF
--- a/star_ratings/admin.py
+++ b/star_ratings/admin.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import app_settings, get_star_ratings_rating_model
 from .models import UserRating


### PR DESCRIPTION
Hi,

There is a deprecation warning under Django 3.0.3, as follows:

> /home/martin/wks/redacted/venv3/lib/python3.6/site-packages/star_ratings/admin.py:21: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
>   stars.short_description = _('Score')
> /home/martin/wks/redacted/venv3/lib/python3.6/site-packages/star_ratings/admin.py:39: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
>   stars.short_description = _('Rating average')

This fixes it. Easy one-character-change pull-request.

Cheers